### PR TITLE
Decode powershell result

### DIFF
--- a/open_in_vscode/__init__.py
+++ b/open_in_vscode/__init__.py
@@ -35,7 +35,7 @@ def find_code():
     if osname == "nt":
         result = run('powershell.exe -Command "Get-Command code | Select-Object -ExpandProperty Definition"', shell=True, stdout=PIPE)
         result.check_returncode()
-        return str(result.stdout)
+        return str(result.stdout.decode("utf-8")).rstrip()
     else:
         return 'code'
 


### PR DESCRIPTION
Im working on win11 the problem was that **find_code()** returned a unformated result **b'pathToCode\r\n'** this resulted in wrong VScode link for **Popen()**.